### PR TITLE
Feature/permit

### DIFF
--- a/contracts/PrimitiveRouter.sol
+++ b/contracts/PrimitiveRouter.sol
@@ -126,6 +126,13 @@ contract PrimitiveRouter is
         emit Initialized(msg.sender);
     }
 
+    /**
+     * @notice  Initialize router with its valid connectors.
+     * @notice  Can only be called once, while initialized == false.
+     * @param   core The address of PrimitiveCore.sol
+     * @param   liquidity The address of PrimitiveLiquidity.sol
+     * @param   swaps The address of PrimitiveSwaps.sol
+     */
     function init(
       address core,
       address liquidity,

--- a/contracts/PrimitiveRouter.sol
+++ b/contracts/PrimitiveRouter.sol
@@ -132,6 +132,7 @@ contract PrimitiveRouter is
       address swaps
     ) external {
       require(initialized == false, "ALREADY_INITIALIZED");
+      initialized = true;
       validConnectors[core] = true;
       validConnectors[liquidity] = true;
       validConnectors[swaps] = true;

--- a/contracts/connectors/PrimitiveConnector.sol
+++ b/contracts/connectors/PrimitiveConnector.sol
@@ -148,6 +148,19 @@ abstract contract PrimitiveConnector is Registered, Context {
         return (0, 0);
     }
 
+    function _mintOptionsPermitted(IOption optionToken, uint256 quantity)
+        internal
+        returns (uint256, uint256)
+    {
+        address underlying = optionToken.getUnderlyingTokenAddress();
+        if (quantity > 0) {
+            IERC20(underlying).transferFrom(msg.sender, address(optionToken), quantity);
+            return optionToken.mintOptions(address(this));
+        }
+
+        return (0, 0);
+    }
+
     function _closeOptions(IOption optionToken) internal returns (uint256) {
         address redeem = optionToken.redeemToken();
         uint256 quantity = IERC20(redeem).balanceOf(address(this));

--- a/contracts/connectors/PrimitiveCore.sol
+++ b/contracts/connectors/PrimitiveCore.sol
@@ -38,6 +38,8 @@ import {
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {IPrimitiveCore, IOption} from "../interfaces/IPrimitiveCore.sol";
 import {PrimitiveConnector} from "./PrimitiveConnector.sol";
+import {IERC20Permit} from "../interfaces/IERC20Permit.sol";
+
 
 import "hardhat/console.sol";
 
@@ -101,6 +103,31 @@ contract PrimitiveCore is PrimitiveConnector, IPrimitiveCore, ReentrancyGuard {
         emit Minted(_msgSender(), address(optionToken), long, short);
         return (long, short);
     }
+
+    /**
+     * @dev     Mints msg.value quantity of options and "quote" (option parameter) quantity of redeem tokens.
+     * @notice  This function is for options that have an EIP2612 (permit) enabled token as the underlying asset.
+     * @param   optionToken The address of the option token to mint.
+     */
+     function safeMintWithPermit
+         (IOption optionToken, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+         external
+         returns (uint256, uint256)
+     {
+         // Permit minting using the caller's underlying tokens
+         IERC20Permit(optionToken.getUnderlyingTokenAddress()).permit(
+             getCaller(),
+             address(this),
+             uint256(-1),
+             deadline,
+             v,
+             r,
+             s
+         );
+         (uint256 long, uint256 short) = _mintOptions(optionToken);
+         emit Minted(_msgSender(), address(optionToken), long, short);
+         return (long, short);
+     }
 
     /**
      * @dev     Swaps msg.value of strikeTokens (ethers) to underlyingTokens.

--- a/contracts/connectors/PrimitiveCore.sol
+++ b/contracts/connectors/PrimitiveCore.sol
@@ -36,10 +36,8 @@ import {
 } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 // Primitive
 import {CoreLib} from "../libraries/CoreLib.sol";
-import {IPrimitiveCore, IOption} from "../interfaces/IPrimitiveCore.sol";
+import {IPrimitiveCore, IOption, IERC20Permit} from "../interfaces/IPrimitiveCore.sol";
 import {PrimitiveConnector} from "./PrimitiveConnector.sol";
-import {IERC20Permit} from "../interfaces/IERC20Permit.sol";
-
 
 import "hardhat/console.sol";
 

--- a/contracts/connectors/PrimitiveCore.sol
+++ b/contracts/connectors/PrimitiveCore.sol
@@ -103,9 +103,10 @@ contract PrimitiveCore is PrimitiveConnector, IPrimitiveCore, ReentrancyGuard {
     }
 
     /**
-     * @dev     Mints msg.value quantity of options and "quote" (option parameter) quantity of redeem tokens.
+     * @dev     Mints "amount" quantity of options and "quote" (option parameter) quantity of redeem tokens.
      * @notice  This function is for options that have an EIP2612 (permit) enabled token as the underlying asset.
      * @param   optionToken The address of the option token to mint.
+     * @param   amount The quantity of options to mint.
      */
      function safeMintWithPermit
          (IOption optionToken, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)

--- a/contracts/connectors/PrimitiveCore.sol
+++ b/contracts/connectors/PrimitiveCore.sol
@@ -110,7 +110,7 @@ contract PrimitiveCore is PrimitiveConnector, IPrimitiveCore, ReentrancyGuard {
      * @param   optionToken The address of the option token to mint.
      */
      function safeMintWithPermit
-         (IOption optionToken, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+         (IOption optionToken, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
          external
          returns (uint256, uint256)
      {
@@ -124,7 +124,7 @@ contract PrimitiveCore is PrimitiveConnector, IPrimitiveCore, ReentrancyGuard {
              r,
              s
          );
-         (uint256 long, uint256 short) = _mintOptions(optionToken);
+         (uint256 long, uint256 short) = _mintOptionsPermitted(optionToken, amount);
          emit Minted(_msgSender(), address(optionToken), long, short);
          return (long, short);
      }

--- a/contracts/connectors/PrimitiveLiquidity.sol
+++ b/contracts/connectors/PrimitiveLiquidity.sol
@@ -170,6 +170,17 @@ contract PrimitiveLiquidity is
         return (amountA, amountB, liquidity);
     }
 
+    /**
+     * @dev     Adds redeemToken liquidity to a redeem<>underlyingToken pair by minting shortOptionTokens with underlyingTokens.
+     * @notice  Pulls underlying tokens from _msgSender() and pushes UNI-V2 liquidity tokens to the "getCaller()" address.
+     *          underlyingToken -> redeemToken -> UNI-V2. Uses permit so user does not need to `approve()` our contracts.
+     * @param   optionAddress The address of the optionToken to get the redeemToken to mint then provide liquidity for.
+     * @param   quantityOptions The quantity of underlyingTokens to use to mint option + redeem tokens.
+     * @param   amountBMax The quantity of underlyingTokens to add with shortOptionTokens to the Uniswap V2 Pair.
+     * @param   amountBMin The minimum quantity of underlyingTokens expected to provide liquidity with.
+     * @param   to The address that receives UNI-V2 shares.
+     * @param   deadline The timestamp to expire a pending transaction.
+     */
     function addShortLiquidityWithUnderlyingWithPermit(
         address optionAddress,
         uint256 quantityOptions,

--- a/contracts/connectors/PrimitiveLiquidity.sol
+++ b/contracts/connectors/PrimitiveLiquidity.sol
@@ -41,9 +41,9 @@ import {
     IUniswapV2Router02,
     IUniswapV2Factory,
     IUniswapV2Pair,
-    IOption
+    IOption,
+    IERC20Permit
 } from "../interfaces/IPrimitiveLiquidity.sol";
-import {IERC20Permit} from "../interfaces/IERC20Permit.sol";
 
 // Primitive
 import {PrimitiveConnector} from "./PrimitiveConnector.sol";

--- a/contracts/connectors/PrimitiveLiquidity.sol
+++ b/contracts/connectors/PrimitiveLiquidity.sol
@@ -43,6 +43,8 @@ import {
     IUniswapV2Pair,
     IOption
 } from "../interfaces/IPrimitiveLiquidity.sol";
+import {IERC20Permit} from "../interfaces/IERC20Permit.sol";
+
 // Primitive
 import {PrimitiveConnector} from "./PrimitiveConnector.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
@@ -166,6 +168,42 @@ contract PrimitiveLiquidity is
 
         emit AddLiquidity(getCaller(), optionAddress, liquidity);
         return (amountA, amountB, liquidity);
+    }
+
+    function addShortLiquidityWithUnderlyingWithPermit(
+        address optionAddress,
+        uint256 quantityOptions,
+        uint256 amountBMax,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256, uint256, uint256) {
+        {
+            uint8 v_ = v;
+            bytes32 r_ = r;
+            bytes32 s_ = s;
+            IERC20Permit(IOption(optionAddress).getUnderlyingTokenAddress()).permit(
+                getCaller(),
+                address(this),
+                uint256(-1),
+                deadline,
+                v_,
+                r_,
+                s_
+            );
+        }
+        return
+            addShortLiquidityWithUnderlying(
+              optionAddress,
+              quantityOptions,
+              amountBMax,
+              amountBMin,
+              to,
+              deadline
+            );
     }
 
     /**

--- a/contracts/interfaces/IERC20Permit.sol
+++ b/contracts/interfaces/IERC20Permit.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.5.0;
+
+interface IERC20Permit {
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+}

--- a/contracts/interfaces/IPrimitiveCore.sol
+++ b/contracts/interfaces/IPrimitiveCore.sol
@@ -24,6 +24,8 @@ pragma solidity ^0.6.2;
 import {
     IOption
 } from "@primitivefi/contracts/contracts/option/interfaces/IOption.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
+
 
 interface IPrimitiveCore {
     function safeMintWithETH(IOption optionToken)

--- a/contracts/interfaces/IPrimitiveLiquidity.sol
+++ b/contracts/interfaces/IPrimitiveLiquidity.sol
@@ -33,6 +33,8 @@ import {
 import {
     IOption
 } from "@primitivefi/contracts/contracts/option/interfaces/IOption.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
+
 
 interface IPrimitiveLiquidity {
     // ==== Liquidity Functions ====


### PR DESCRIPTION
Add IERC20Permit interface.
Add permit logic to option minting when underlying is permit-enabled token.
Implement `init` to set whitelisted connectors in PrimitiveRouter.
`halt` to cease all router operations.